### PR TITLE
Retire Proxy Handling

### DIFF
--- a/src/splinterlands.js
+++ b/src/splinterlands.js
@@ -516,7 +516,9 @@ var splinterlands = (function () {
         let broadcast_promise = null;
 
         if (_player.use_proxy) {
-            broadcast_promise = new Promise(resolve => {
+            return {success: false, error: 'Non-Hive accounts cannot broadcast transactions.  Purchasing a Spell Book and choosing a name will automatically add a Hive account.'};
+			/*
+			broadcast_promise = new Promise(resolve => {
                 splinterlands.utils.post(`${_config.tx_broadcast_url}/proxy`, {
                     player: _player.name,
                     access_token: _player.token,
@@ -526,6 +528,7 @@ var splinterlands = (function () {
                     .then(r => resolve({type: 'broadcast', method: 'proxy', success: true, trx_id: r.id}))
                     .catch(err => resolve({type: 'broadcast', method: 'proxy', success: true, error: err}));
             });
+			*/
         } else if (_use_keychain) {
             broadcast_promise = new Promise(resolve => hive_keychain.requestCustomJson(_player.name, id, active_auth ? 'Active' : 'Posting', data_str, display_name, response => {
                 resolve({


### PR DESCRIPTION
After moving all free-to-play actions to API calls, removing Proxy blockchain posting for non-Hive accounts.